### PR TITLE
Extended offset accepted range of _EPROCESS from 0x400 to 0x600.

### DIFF
--- a/CapcomLoader.h
+++ b/CapcomLoader.h
@@ -87,7 +87,7 @@ static std::wstring Cl_GetDriverPath()
 
 static NTSTATUS Cl_RemoveSimilarDrivers( BYTE* Driver )
 {
-	namespace fs = std::experimental::filesystem;
+	namespace fs = std::filesystem;
 
 	std::wstring DriverPath = Cl_GetDriverPath();
 

--- a/MemoryController.h
+++ b/MemoryController.h
@@ -433,13 +433,13 @@ static MemoryController Mc_InitContext( CapcomContext** CpCtxReuse = 0, KernelCo
 				uint64_t Pid = k_PsGetProcessId( Controller.CurrentEProcess );
 
 				uint32_t PidOffset = *( uint32_t* ) ( ( PUCHAR ) k_PsGetProcessId + 3 );
-				if ( PidOffset < 0x400 && *( uint64_t* ) ( Controller.CurrentEProcess + PidOffset ) == Pid )
+				if ( PidOffset < 0x600 && *( uint64_t* ) ( Controller.CurrentEProcess + PidOffset ) == Pid )
 				{
 					Controller.UniqueProcessIdOffset = PidOffset;
 					Controller.ActiveProcessLinksOffset = Controller.UniqueProcessIdOffset + 0x8;
 				}
 
-				for ( int i = 0; i < 0x400; i += 0x8 )
+				for ( int i = 0; i < 0x600; i += 0x8 )
 				{
 					uint64_t* Ptr = (uint64_t*)(Controller.CurrentEProcess + i);
 					if ( !Controller.UniqueProcessIdOffset && Ptr[ 0 ] & 0xFFFFFFFF == Pid && ( Ptr[ 1 ] > 0xffff800000000000 ) && ( Ptr[ 2 ] > 0xffff800000000000 ) && ( ( Ptr[ 1 ] & 0xF ) == ( Ptr[ 2 ] & 0xF ) ) )


### PR DESCRIPTION
UniqueProcessIdOffset is currently at 0x448 on the latest Windows update.